### PR TITLE
Add link to Confluent Community Slack

### DIFF
--- a/social.md
+++ b/social.md
@@ -6,6 +6,7 @@
 ## Chats
 
 * IRC: chat.freenode.net in #apache-kafka
+* [Confluent Community Slack](https://launchpass.com/confluentcommunity)
 
 ## Mailing Lists
 


### PR DESCRIPTION
This adds a link to the Confluent Community Slack.

> This Slack Team will focus on the Apache Kafka® technology and its ecosystem, also allowing its members to interact and share their use cases, do and don't, how to's, etc.
> We will also hear about the Confluent Platform and topics like Kafka's Connect API and streaming data pipelines, Kafka’s Streams API and stream processing, Security, Microservices and anything else related to Apache Kafka.