### PR TITLE
Update kafka-ui URL

### DIFF
--- a/tools.md
+++ b/tools.md
@@ -55,7 +55,7 @@ Table of Contents
 * [Kafka Topics UI](https://github.com/Landoop/kafka-topics-ui)
 * [Kafka Connect UI](https://github.com/Landoop/kafka-connect-ui)
 * [Kafka Schema UI](https://github.com/Landoop/schema-registry-ui)
-* [UI for Apache Kafka](https://github.com/provectus/kafka-ui)
+* [UI for Apache Kafka](https://github.com/kafbat/kafka-ui)
 
 
 ## Mirroring 


### PR DESCRIPTION
Hi! 

This PR updates kafka-ui URL previously introduced in #24 as we've moved the repos [0] [1]

[0] - https://github.com/provectus/kafka-ui/discussions/4255
[1] - https://github.com/kafbat/kafka-ui/discussions/23

Thanks!

cc @germanosin 